### PR TITLE
Add keywords to composer configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,15 @@
 {
     "name": "firehed/security",
     "description": "Security tools for PHP",
+    "keywords": [
+        "security",
+        "secret",
+        "string",
+        "hidden",
+        "masked",
+        "sensitive",
+        "password"
+    ],
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
Right now searching Packagist for "secret string" or "hidden string" will not display this package as a result. That makes it hard to discover this package, even when you know what you are looking for.