### PR TITLE
Clean up exported files

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,7 +1,0 @@
-{
-    "unit.engine": "Firehed\\Arctools\\Unit\\PHPUnitTestEngine",
-    "unit.phpunit.binary": "vendor/bin/phpunit",
-    "load": [
-        "vendor/firehed/arctools/src"
-    ]
-}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpcs.xml export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml export-ignore
+
+*.php diff=php


### PR DESCRIPTION
Sets up a `.gitattributes` file to avoid shipping tests, etc., to dependents.