### PR TITLE
Update PHPUnit to v11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^11.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "suggest": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,26 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         cacheResultFile=".phpunit.cache/test-results"
-         executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="false"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" displayDetailsOnAllIssues="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="false">
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" displayDetailsOnAllIssues="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="false">
-  <testsuites>
-    <testsuite name="default">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
-  <source>
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         requireCoverageMetadata="true"
+         beStrictAboutCoverageMetadata="false"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnAllIssues="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/HOTPTest.php
+++ b/tests/HOTPTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Firehed\Security;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(OTP::class)]
-#[CoversClass(\Firehed\Security\HOTP::class)]
+#[CoversFunction('Firehed\Security\HOTP')]
 class HOTPTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/HOTPTest.php
+++ b/tests/HOTPTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Firehed\Security;
 
-/**
- * @covers Firehed\Security\OTP
- * @covers Firehed\Security\HOTP
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(OTP::class)]
+#[CoversClass(\Firehed\Security\HOTP::class)]
 class HOTPTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -17,7 +18,7 @@ class HOTPTest extends \PHPUnit\Framework\TestCase
      *
      * @return array{Secret, int, string}[]
      */
-    public function vectors(): array
+    public static function vectors(): array
     {
         $secret = new Secret('12345678901234567890');
         return [
@@ -34,9 +35,7 @@ class HOTPTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider vectors
-     */
+    #[DataProvider('vectors')]
     public function testHOTP(Secret $secret, int $counter, string $out): void
     {
         self::assertSame(

--- a/tests/SecretKeyTest.php
+++ b/tests/SecretKeyTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Firehed\Security;
 
-/**
- * @covers Firehed\Security\SecretKey
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(SecretKey::class)]
 class SecretKeyTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetKey(): void

--- a/tests/SecretTest.php
+++ b/tests/SecretTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Firehed\Security;
 
-/**
- * @covers Firehed\Security\Secret
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Secret::class)]
 class SecretTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct(): void

--- a/tests/TOTPTest.php
+++ b/tests/TOTPTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Firehed\Security;
 
-/**
- * @covers Firehed\Security\OTP
- * @covers Firehed\Security\TOTP
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(OTP::class)]
+#[CoversClass(\Firehed\Security\TOTP::class)]
 class TOTPTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -15,7 +16,7 @@ class TOTPTest extends \PHPUnit\Framework\TestCase
      *
      * @return array{int, string, 'sha1'|'sha256'|'sha512', Secret}[]
      */
-    public function TOTPvectors(): array
+    public static function TOTPvectors(): array
     {
         // It's unclear that the token is of varying length based on the
         // algoritm being used, but that's definitely the case
@@ -46,9 +47,9 @@ class TOTPTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider TOTPvectors
      * @param 'sha1'|'sha256'|'sha512' $algo
      */
+    #[DataProvider('TOTPvectors')]
     public function testTOTPVectors(
         int $ts,
         string $expectedOut,

--- a/tests/TOTPTest.php
+++ b/tests/TOTPTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Firehed\Security;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(OTP::class)]
-#[CoversClass(\Firehed\Security\TOTP::class)]
+#[CoversFunction('Firehed\Security\TOTP')]
 class TOTPTest extends \PHPUnit\Framework\TestCase
 {
     /**


### PR DESCRIPTION
## Summary
- Update phpunit/phpunit from ^9.0 to ^11.0
- Migrate phpunit.xml to PHPUnit 11 schema
- Make data providers static (required in PHPUnit 11)
- Convert annotations to PHP 8 attributes

## Test plan
- [ ] Verify CI passes on all PHP versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)