### PR TITLE
Remove deprecated --no-suggest flag

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,6 @@ jobs:
           --no-ansi
           --no-interaction
           --no-progress
-          --no-suggest
           --prefer-dist
 
       - name: PHPCS

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -34,7 +34,6 @@ jobs:
           --no-ansi
           --no-interaction
           --no-progress
-          --no-suggest
           --prefer-dist
 
       - name: PHPStan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
           --no-ansi
           --no-interaction
           --no-progress
-          --no-suggest
           --prefer-dist
 
       - name: PHPUnit


### PR DESCRIPTION
## Summary
- Remove `--no-suggest` from composer update commands in all workflows
- This flag was removed in Composer 2.2 and does nothing

## Test plan
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)