### PR TITLE
Add Algorithm enum for OTP hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Algorithm` enum for OTP hashing algorithms
+
+### Changed
+
+- `OTP::getHOTP()` and `OTP::getTOTP()` now accept `Algorithm` enum instead of string
+- `OTP::ALGORITHM_*` constants are deprecated; use `Algorithm` enum directly
+
 ### Removed
 
 - **BREAKING**: `HOTP()` and `TOTP()` functions have been removed. Use the `OTP` class directly instead.

--- a/src/Algorithm.php
+++ b/src/Algorithm.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Security;
+
+enum Algorithm: string
+{
+    case SHA1 = 'sha1';
+    case SHA256 = 'sha256';
+    case SHA512 = 'sha512';
+}

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\Security;
 
-use DomainException;
 use LengthException;
 
 use function assert;
@@ -20,9 +19,12 @@ use function unpack;
 
 class OTP
 {
-    public const ALGORITHM_SHA1 = 'sha1';
-    public const ALGORITHM_SHA256 = 'sha256';
-    public const ALGORITHM_SHA512 = 'sha512';
+    /** @deprecated Use Algorithm::SHA1 instead */
+    public const ALGORITHM_SHA1 = Algorithm::SHA1;
+    /** @deprecated Use Algorithm::SHA256 instead */
+    public const ALGORITHM_SHA256 = Algorithm::SHA256;
+    /** @deprecated Use Algorithm::SHA512 instead */
+    public const ALGORITHM_SHA512 = Algorithm::SHA512;
 
     /** @var Secret */
     private $secret;
@@ -45,22 +47,12 @@ class OTP
      *
      * @param int $counter 8-byte counter
      * @param int<6, 8> $digits = 6 Length of the output code
-     * @param 'sha1'|'sha256'|'sha512' $algorithm = 'sha1' HMAC algorithm
      *
      * @return string The $digits-character numeric code
      */
-    public function getHOTP(int $counter, int $digits = 6, string $algorithm = self::ALGORITHM_SHA1): string
+    public function getHOTP(int $counter, int $digits = 6, Algorithm $algorithm = Algorithm::SHA1): string
     {
-        /** @var string $algorithm (don't rely on build-time types) */
-        if (
-            $algorithm !== self::ALGORITHM_SHA1
-            && $algorithm !== self::ALGORITHM_SHA256
-            && $algorithm !== self::ALGORITHM_SHA512
-        ) {
-            throw new DomainException('Invalid algorithm');
-        }
-
-        /** @var int $digits (same as above) @phpstan-ignore varTag.type */
+        /** @var int $digits @phpstan-ignore varTag.type */
         if ($digits < 6 || $digits > 8) {
             // "Implementations MUST extract a 6-digit code at a minimum and
             // possibly 7 and 8-digit code."
@@ -78,7 +70,7 @@ class OTP
         $counter = pack('J', $counter); // Convert to 8-byte string
 
         // 5.3 Step 1: Generate hash value
-        $hash = hash_hmac($algorithm, $counter, $this->secret->reveal(), true);
+        $hash = hash_hmac($algorithm->value, $counter, $this->secret->reveal(), true);
 
         $dbc = self::dynamicTruncate($hash);
         // 5.3 Step 3: Compute HOTP value
@@ -100,9 +92,6 @@ class OTP
      *
      * @param int<6, 8> $digits = 6 The number of digits in the output code
      *
-     * @param self::ALGORITHM_* $algorithm = self::ALGORITHM_SHA1 The hashing
-     * algorithm to use with the key and generated counter.
-     *
      * To address clock drift and slow inputs, the $t0 parameter may be used to
      * check for the next and/or previous code. This will adjust the time by the
      * given number of seconds; as such, it's advisable to use values that are
@@ -117,7 +106,7 @@ class OTP
         int $step = 30,
         int $t0 = 0,
         int $digits = 6,
-        string $algorithm = self::ALGORITHM_SHA1
+        Algorithm $algorithm = Algorithm::SHA1,
     ): string {
         $t = (int) floor((time() - $t0) / $step);
         return $this->getHOTP($t, $digits, $algorithm);

--- a/tests/HOTPTest.php
+++ b/tests/HOTPTest.php
@@ -45,18 +45,6 @@ class HOTPTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testBadAlgorithm(): void
-    {
-        $this->expectException(\DomainException::class);
-        $otp = new OTP(new Secret('abcdefgijklmnopqrstuvwxyz'));
-        $otp->getHOTP(
-            0x1234567890123456,
-            6,
-            // @phpstan-ignore argument.type (testing type mismatch)
-            'notalg'
-        );
-    }
-
     public function testTooFewDigits(): void
     {
         $this->expectException(\LengthException::class);

--- a/tests/TOTPTest.php
+++ b/tests/TOTPTest.php
@@ -13,7 +13,7 @@ class TOTPTest extends \PHPUnit\Framework\TestCase
     /**
      * Test vectors provided by RFC 6238, Appendix B
      *
-     * @return array{int, string, 'sha1'|'sha256'|'sha512', Secret}[]
+     * @return array{int, string, Algorithm, Secret}[]
      */
     public static function TOTPvectors(): array
     {
@@ -24,35 +24,32 @@ class TOTPTest extends \PHPUnit\Framework\TestCase
         $tok_sha256 = new Secret(substr($base, 0, 32));
         $tok_sha512 = new Secret(substr($base, 0, 64));
         return [
-            [         59, '94287082', 'sha1'  , $tok_sha1  ],
-            [         59, '46119246', 'sha256', $tok_sha256],
-            [         59, '90693936', 'sha512', $tok_sha512],
-            [ 1111111109, '07081804', 'sha1'  , $tok_sha1  ],
-            [ 1111111109, '68084774', 'sha256', $tok_sha256],
-            [ 1111111109, '25091201', 'sha512', $tok_sha512],
-            [ 1111111111, '14050471', 'sha1'  , $tok_sha1  ],
-            [ 1111111111, '67062674', 'sha256', $tok_sha256],
-            [ 1111111111, '99943326', 'sha512', $tok_sha512],
-            [ 1234567890, '89005924', 'sha1'  , $tok_sha1  ],
-            [ 1234567890, '91819424', 'sha256', $tok_sha256],
-            [ 1234567890, '93441116', 'sha512', $tok_sha512],
-            [ 2000000000, '69279037', 'sha1'  , $tok_sha1  ],
-            [ 2000000000, '90698825', 'sha256', $tok_sha256],
-            [ 2000000000, '38618901', 'sha512', $tok_sha512],
-            [20000000000, '65353130', 'sha1'  , $tok_sha1  ],
-            [20000000000, '77737706', 'sha256', $tok_sha256],
-            [20000000000, '47863826', 'sha512', $tok_sha512],
+            [         59, '94287082', Algorithm::SHA1  , $tok_sha1  ],
+            [         59, '46119246', Algorithm::SHA256, $tok_sha256],
+            [         59, '90693936', Algorithm::SHA512, $tok_sha512],
+            [ 1111111109, '07081804', Algorithm::SHA1  , $tok_sha1  ],
+            [ 1111111109, '68084774', Algorithm::SHA256, $tok_sha256],
+            [ 1111111109, '25091201', Algorithm::SHA512, $tok_sha512],
+            [ 1111111111, '14050471', Algorithm::SHA1  , $tok_sha1  ],
+            [ 1111111111, '67062674', Algorithm::SHA256, $tok_sha256],
+            [ 1111111111, '99943326', Algorithm::SHA512, $tok_sha512],
+            [ 1234567890, '89005924', Algorithm::SHA1  , $tok_sha1  ],
+            [ 1234567890, '91819424', Algorithm::SHA256, $tok_sha256],
+            [ 1234567890, '93441116', Algorithm::SHA512, $tok_sha512],
+            [ 2000000000, '69279037', Algorithm::SHA1  , $tok_sha1  ],
+            [ 2000000000, '90698825', Algorithm::SHA256, $tok_sha256],
+            [ 2000000000, '38618901', Algorithm::SHA512, $tok_sha512],
+            [20000000000, '65353130', Algorithm::SHA1  , $tok_sha1  ],
+            [20000000000, '77737706', Algorithm::SHA256, $tok_sha256],
+            [20000000000, '47863826', Algorithm::SHA512, $tok_sha512],
         ];
     }
 
-    /**
-     * @param 'sha1'|'sha256'|'sha512' $algo
-     */
     #[DataProvider('TOTPvectors')]
     public function testTOTPVectors(
         int $ts,
         string $expectedOut,
-        string $algo,
+        Algorithm $algo,
         Secret $key,
     ): void {
         // Note: this isn't really the intended use of T0, as it's really meant


### PR DESCRIPTION
## Summary
- Add `Algorithm` enum with SHA1, SHA256, SHA512 cases
- Update `OTP::getHOTP()` and `OTP::getTOTP()` to use `Algorithm` enum
- Deprecate `OTP::ALGORITHM_*` constants (now point to enum values for backwards compatibility)
- Update tests

## Backwards Compatibility
The deprecated constants now return `Algorithm` enum values, so existing code using `OTP::ALGORITHM_SHA1` etc. will continue to work.

## Test plan
- [x] PHPUnit passes
- [x] PHPStan passes

Generated with [Claude Code](https://claude.com/claude-code)